### PR TITLE
fix(jsr-498): erase history on replace to prevent ctrl-z

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://github.com/TypeCellOS/BlockNote",
   "private": false,
   "license": "MPL-2.0",
-  "version": "0.10.0-dev.0",
+  "version": "0.10.0-dev.3",
   "files": [
     "dist",
     "types",

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -549,7 +549,7 @@ export class BlockNoteEditor<
         // initial content, as the schema may contain custom blocks which need
         // it to render.
         if (initialContent !== undefined) {
-          this.replaceBlocks(this.topLevelBlocks, initialContent as any);
+          this.replaceBlocks(this.topLevelBlocks, initialContent as any, true);
         }
 
         newOptions.onEditorReady?.(this);
@@ -1001,9 +1001,10 @@ export class BlockNoteEditor<
    */
   public replaceBlocks(
     blocksToRemove: BlockIdentifier[],
-    blocksToInsert: PartialBlock<BSchema, ISchema, SSchema>[]
+    blocksToInsert: PartialBlock<BSchema, ISchema, SSchema>[],
+    eraseHistory = false
   ) {
-    replaceBlocks(blocksToRemove, blocksToInsert, this);
+    replaceBlocks(blocksToRemove, blocksToInsert, this, eraseHistory);
   }
 
   /**

--- a/tests/src/utils/components/Editor.tsx
+++ b/tests/src/utils/components/Editor.tsx
@@ -23,7 +23,7 @@ export default function Editor() {
     image: Image,
     separator: Separator,
     // toc: TableOfContents,
-  };
+  } as any;
 
   const slashMenuItems = [
     insertAlert,


### PR DESCRIPTION
ctr-z twice will cause all content removed, because when page first load, the library used replaceBlocks, which will actually create a transaction, and user can ctrl-z then all content is erased. this will remove that transaction from history

https://jitera.atlassian.net/browse/JSR-498

https://github.com/Jitera-Product/BlockNote/assets/48788462/a5b67afe-a83c-4e9d-a0f2-9a0eed96f8db

